### PR TITLE
fix: use PowerShell instead of bash in README examples

### DIFF
--- a/.github/DRAFT_README.md
+++ b/.github/DRAFT_README.md
@@ -28,7 +28,10 @@ default workflow context.
     github_token: ${{ secrets.GITHUB_TOKEN }}
 
 - name: Display Job Summary URL
-  run: echo "Job Summary: ${{ steps.job-info.outputs.job_summary_url }}"
+  env:
+    JOB_SUMMARY_URL: ${{ steps.job-info.outputs.job_summary_url }}
+  shell: pwsh
+  run: Write-Output "Job Summary: $env:JOB_SUMMARY_URL"
 ```
 
 ## Inputs

--- a/README.md
+++ b/README.md
@@ -28,7 +28,10 @@ default workflow context.
     github_token: ${{ secrets.GITHUB_TOKEN }}
 
 - name: Display Job Summary URL
-  run: echo "Job Summary: ${{ steps.job-info.outputs.job_summary_url }}"
+  env:
+    JOB_SUMMARY_URL: ${{ steps.job-info.outputs.job_summary_url }}
+  shell: pwsh
+  run: Write-Output "Job Summary: $env:JOB_SUMMARY_URL"
 ```
 
 ## Inputs


### PR DESCRIPTION
## Summary
- Updated README.md and DRAFT_README.md to use PowerShell (pwsh) instead of bash
- Changed direct steps context references to use environment variables
- Modified echo commands to PowerShell Write-Output commands

## Changes
- Replace `echo` with `Write-Output` 
- Add `shell: pwsh` to specify PowerShell execution
- Pass steps context values through environment variables instead of direct interpolation

## Test plan
- [x] Verify the PowerShell syntax is correct
- [ ] Confirm examples work as expected in GitHub Actions

🤖 Generated with [Claude Code](https://claude.ai/code)