### PR TITLE
fix: exclude Dependabot PRs from Claude Code Review

### DIFF
--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -77,7 +77,8 @@ jobs:
           JOB_URL: ${{ steps.test-action.outputs.job_url }}
           JOB_SUMMARY_URL: ${{ steps.test-action.outputs.job_summary_url }}
           WORKFLOW_NAME: ${{ steps.test-action.outputs.workflow_name }}
-          JOB_SUMMARY_URL_ANCHOR: ${{ steps.test-action-anchor.outputs.job_summary_url }}
+          JOB_SUMMARY_URL_ANCHOR:
+            ${{ steps.test-action-anchor.outputs.job_summary_url }}
         run: |
           echo "=== Without Anchor ==="
           echo "Run URL: $RUN_URL"
@@ -100,7 +101,8 @@ jobs:
           JOB_STATUS: ${{ steps.test-action.outputs.job_status }}
           WORKFLOW_NAME: ${{ steps.test-action.outputs.workflow_name }}
           RUN_NUMBER: ${{ steps.test-action.outputs.run_number }}
-          JOB_SUMMARY_URL_ANCHOR: ${{ steps.test-action-anchor.outputs.job_summary_url }}
+          JOB_SUMMARY_URL_ANCHOR:
+            ${{ steps.test-action-anchor.outputs.job_summary_url }}
         run: |
           {
             echo "# GitHub Actions Test Job Summary"

--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -70,19 +70,37 @@ jobs:
 
       - name: Print Outputs
         id: output
+        env:
+          RUN_URL: ${{ steps.test-action.outputs.run_url }}
+          JOB_ID: ${{ steps.test-action.outputs.job_id }}
+          JOB_NAME: ${{ steps.test-action.outputs.job_name }}
+          JOB_URL: ${{ steps.test-action.outputs.job_url }}
+          JOB_SUMMARY_URL: ${{ steps.test-action.outputs.job_summary_url }}
+          WORKFLOW_NAME: ${{ steps.test-action.outputs.workflow_name }}
+          JOB_SUMMARY_URL_ANCHOR: ${{ steps.test-action-anchor.outputs.job_summary_url }}
         run: |
           echo "=== Without Anchor ==="
-          echo "Run URL: ${{ steps.test-action.outputs.run_url }}"
-          echo "Job ID: ${{ steps.test-action.outputs.job_id }}"
-          echo "Job Name: ${{ steps.test-action.outputs.job_name }}"
-          echo "Job URL: ${{ steps.test-action.outputs.job_url }}"
-          echo "Job Summary URL: ${{ steps.test-action.outputs.job_summary_url }}"
-          echo "Workflow Name: ${{ steps.test-action.outputs.workflow_name }}"
+          echo "Run URL: $RUN_URL"
+          echo "Job ID: $JOB_ID"
+          echo "Job Name: $JOB_NAME"
+          echo "Job URL: $JOB_URL"
+          echo "Job Summary URL: $JOB_SUMMARY_URL"
+          echo "Workflow Name: $WORKFLOW_NAME"
           echo ""
           echo "=== With Anchor ==="
-          echo "Job Summary URL (with anchor): ${{ steps.test-action-anchor.outputs.job_summary_url }}"
+          echo "Job Summary URL (with anchor): $JOB_SUMMARY_URL_ANCHOR"
 
       - name: Write Job Summary
+        env:
+          RUN_URL: ${{ steps.test-action.outputs.run_url }}
+          JOB_ID: ${{ steps.test-action.outputs.job_id }}
+          JOB_NAME: ${{ steps.test-action.outputs.job_name }}
+          JOB_URL: ${{ steps.test-action.outputs.job_url }}
+          JOB_SUMMARY_URL: ${{ steps.test-action.outputs.job_summary_url }}
+          JOB_STATUS: ${{ steps.test-action.outputs.job_status }}
+          WORKFLOW_NAME: ${{ steps.test-action.outputs.workflow_name }}
+          RUN_NUMBER: ${{ steps.test-action.outputs.run_number }}
+          JOB_SUMMARY_URL_ANCHOR: ${{ steps.test-action-anchor.outputs.job_summary_url }}
         run: |
           {
             echo "# GitHub Actions Test Job Summary"
@@ -93,20 +111,20 @@ jobs:
             echo ""
             echo "| Output | Value |"
             echo "|--------:|-------|"
-            echo "| Run URL | ${{ steps.test-action.outputs.run_url }} |"
-            echo "| Job ID | ${{ steps.test-action.outputs.job_id }} |"
-            echo "| Job Name | ${{ steps.test-action.outputs.job_name }} |"
-            echo "| Job URL | ${{ steps.test-action.outputs.job_url }} |"
-            echo "| Job Summary URL | ${{ steps.test-action.outputs.job_summary_url }} |"
-            echo "| Job Status | ${{ steps.test-action.outputs.job_status }} |"
-            echo "| Workflow Name | ${{ steps.test-action.outputs.workflow_name }} |"
-            echo "| Run Number | ${{ steps.test-action.outputs.run_number }} |"
+            echo "| Run URL | $RUN_URL |"
+            echo "| Job ID | $JOB_ID |"
+            echo "| Job Name | $JOB_NAME |"
+            echo "| Job URL | $JOB_URL |"
+            echo "| Job Summary URL | $JOB_SUMMARY_URL |"
+            echo "| Job Status | $JOB_STATUS |"
+            echo "| Workflow Name | $WORKFLOW_NAME |"
+            echo "| Run Number | $RUN_NUMBER |"
             echo ""
             echo "## Action Outputs (With Anchor)"
             echo ""
             echo "| Output | Value |"
             echo "|--------:|-------|"
-            echo "| Job Summary URL (with anchor) | ${{ steps.test-action-anchor.outputs.job_summary_url }} |"
+            echo "| Job Summary URL (with anchor) | $JOB_SUMMARY_URL_ANCHOR |"
             echo ""
             echo "✅ Test completed successfully!"
           } >> "$GITHUB_STEP_SUMMARY"

--- a/.github/workflows/claude-code-review.yml
+++ b/.github/workflows/claude-code-review.yml
@@ -13,7 +13,7 @@ on:
 jobs:
   claude-review:
     # Skip Dependabot PRs
-    if: github.actor != 'dependabot[bot]'
+    if: ${{ github.actor != 'dependabot[bot]' }}
     # Optional: Filter by PR author
     # if: |
     #   github.event.pull_request.user.login == 'external-contributor' ||

--- a/.github/workflows/claude-code-review.yml
+++ b/.github/workflows/claude-code-review.yml
@@ -21,9 +21,11 @@ jobs:
     #   github.event.pull_request.author_association == 'FIRST_TIME_CONTRIBUTOR'
 
     runs-on: ubuntu-latest
-    permissions: # checkov:skip=CKV2_GHA_1 id-token write permission is required for OIDC authentication with Claude
+    # checkov:skip=CKV2_GHA_1
+    # id-token write permission is required for OIDC authentication with Claude
+    permissions:
       contents: read
-      pull-requests: write # Changed from read - Claude needs write to post review comments
+      pull-requests: write # Claude needs write to post review comments
       issues: write # Changed from read - Claude needs write to post comments
       id-token: write
 
@@ -56,14 +58,17 @@ jobs:
           # direct_prompt: |
           #   Review this PR focusing on:
           #   - For TypeScript files: Type safety and proper interface usage
-          #   - For API endpoints: Security, input validation, and error handling
-          #   - For React components: Performance, accessibility, and best practices
+          #   - For API endpoints: Security, input validation, error handling
+          #   - For React components: Performance, accessibility, best practices
           #   - For tests: Coverage, edge cases, and test quality
 
           # Optional: Different prompts for different authors
           # direct_prompt: |
-          #   ${{ github.event.pull_request.author_association == 'FIRST_TIME_CONTRIBUTOR' &&
-          #   'Welcome! Please review this PR from a first-time contributor. Be encouraging and provide detailed explanations for any suggestions.' ||
+          #   ${{ github.event.pull_request.author_association ==
+          #   'FIRST_TIME_CONTRIBUTOR' &&
+          #   'Welcome! Please review this PR from a first-time contributor.
+          #   Be encouraging and provide detailed explanations for any
+          #   suggestions.' ||
           #   'Please provide a thorough code review focusing on our
           #   coding standards and best practices.' }}
 

--- a/.github/workflows/claude-code-review.yml
+++ b/.github/workflows/claude-code-review.yml
@@ -12,6 +12,8 @@ on:
 
 jobs:
   claude-review:
+    # Skip Dependabot PRs
+    if: github.actor != 'dependabot[bot]'
     # Optional: Filter by PR author
     # if: |
     #   github.event.pull_request.user.login == 'external-contributor' ||

--- a/.github/workflows/claude-code-review.yml
+++ b/.github/workflows/claude-code-review.yml
@@ -64,7 +64,8 @@ jobs:
           # direct_prompt: |
           #   ${{ github.event.pull_request.author_association == 'FIRST_TIME_CONTRIBUTOR' &&
           #   'Welcome! Please review this PR from a first-time contributor. Be encouraging and provide detailed explanations for any suggestions.' ||
-          #   'Please provide a thorough code review focusing on our coding standards and best practices.' }}
+          #   'Please provide a thorough code review focusing on our
+          #   coding standards and best practices.' }}
 
           allowed_tools: |
             "Bash(npm run test),Bash(npm run lint),Bash(npm run typecheck)"

--- a/.github/workflows/claude.yml
+++ b/.github/workflows/claude.yml
@@ -12,12 +12,11 @@ on:
 
 jobs:
   claude:
-    if: ${{ |
-      (github.event_name == 'issue_comment' && contains(github.event.comment.body, '@claude')) ||
+    if: |
+      ${{ (github.event_name == 'issue_comment' && contains(github.event.comment.body, '@claude')) ||
       (github.event_name == 'pull_request_review_comment' && contains(github.event.comment.body, '@claude')) ||
       (github.event_name == 'pull_request_review' && contains(github.event.review.body, '@claude')) ||
-      (github.event_name == 'issues' && (contains(github.event.issue.body, '@claude') || contains(github.event.issue.title, '@claude')))
-    }}
+      (github.event_name == 'issues' && (contains(github.event.issue.body, '@claude') || contains(github.event.issue.title, '@claude'))) }}
     runs-on: ubuntu-latest
     permissions: # checkov:skip=CKV2_GHA_1 id-token write permission is required for OIDC authentication with Claude
       contents: read

--- a/.github/workflows/claude.yml
+++ b/.github/workflows/claude.yml
@@ -13,15 +13,22 @@ on:
 jobs:
   claude:
     if: |
-      ${{ (github.event_name == 'issue_comment' && contains(github.event.comment.body, '@claude')) ||
-      (github.event_name == 'pull_request_review_comment' && contains(github.event.comment.body, '@claude')) ||
-      (github.event_name == 'pull_request_review' && contains(github.event.review.body, '@claude')) ||
-      (github.event_name == 'issues' && (contains(github.event.issue.body, '@claude') || contains(github.event.issue.title, '@claude'))) }}
+      ${{ (github.event_name == 'issue_comment' &&
+           contains(github.event.comment.body, '@claude')) ||
+          (github.event_name == 'pull_request_review_comment' &&
+           contains(github.event.comment.body, '@claude')) ||
+          (github.event_name == 'pull_request_review' &&
+           contains(github.event.review.body, '@claude')) ||
+          (github.event_name == 'issues' &&
+           (contains(github.event.issue.body, '@claude') ||
+            contains(github.event.issue.title, '@claude'))) }}
     runs-on: ubuntu-latest
-    permissions: # checkov:skip=CKV2_GHA_1 id-token write permission is required for OIDC authentication with Claude
+    # checkov:skip=CKV2_GHA_1
+    # id-token write permission is required for OIDC authentication with Claude
+    permissions:
       contents: read
-      pull-requests: write # Changed from read - Claude needs write to post comments
-      issues: write # Changed from read - Claude needs write to post comments
+      pull-requests: write # Claude needs write to post comments
+      issues: write # Claude needs write to post comments
       id-token: write
       actions: read # Required for Claude to read CI results on PRs
     steps:
@@ -32,10 +39,10 @@ jobs:
 
       - name: Run Claude Code
         id: claude
-        uses: anthropics/claude-code-action@cefe963a6b4ae0e511c59b9d6cb6b7b5923714a1
+        uses: anthropics/claude-code-action@cefe963a6b4ae0e511c59b9d6cb6b7b5923714a1  # yamllint disable-line rule:line-length
         with:
           claude_code_oauth_token: ${{ secrets.CLAUDE_CODE_OAUTH_TOKEN }}
-          # This is an optional setting that allows Claude to read CI results on PRs
+          # Optional setting that allows Claude to read CI results on PRs
           additional_permissions: |
             actions: read
           model: 'claude-opus-4-20250514'
@@ -46,9 +53,11 @@ jobs:
           # assignee_trigger: "claude-bot"
 
           allowed_tools: |
-            "Bash(npm install),Bash(npm run build),Bash(npm run test:*),Bash(npm run lint:*)"
+            "Bash(npm install),Bash(npm run build),"
+            "Bash(npm run test:*),Bash(npm run lint:*)"
 
-          # Optional: Add custom instructions for Claude to customize its behavior for your project
+          # Optional: Add custom instructions for Claude to customize
+          # its behavior for your project
           # custom_instructions: |
           #   Follow our coding standards
           #   Ensure all new code has tests

--- a/.github/workflows/claude.yml
+++ b/.github/workflows/claude.yml
@@ -12,11 +12,12 @@ on:
 
 jobs:
   claude:
-    if: |
+    if: ${{ |
       (github.event_name == 'issue_comment' && contains(github.event.comment.body, '@claude')) ||
       (github.event_name == 'pull_request_review_comment' && contains(github.event.comment.body, '@claude')) ||
       (github.event_name == 'pull_request_review' && contains(github.event.review.body, '@claude')) ||
       (github.event_name == 'issues' && (contains(github.event.issue.body, '@claude') || contains(github.event.issue.title, '@claude')))
+    }}
     runs-on: ubuntu-latest
     permissions: # checkov:skip=CKV2_GHA_1 id-token write permission is required for OIDC authentication with Claude
       contents: read

--- a/.github/workflows/claude.yml
+++ b/.github/workflows/claude.yml
@@ -12,16 +12,14 @@ on:
 
 jobs:
   claude:
-    if: |
+    if: >-
       ${{ (github.event_name == 'issue_comment' &&
-           contains(github.event.comment.body, '@claude')) ||
-          (github.event_name == 'pull_request_review_comment' &&
-           contains(github.event.comment.body, '@claude')) ||
-          (github.event_name == 'pull_request_review' &&
-           contains(github.event.review.body, '@claude')) ||
-          (github.event_name == 'issues' &&
-           (contains(github.event.issue.body, '@claude') ||
-            contains(github.event.issue.title, '@claude'))) }}
+      contains(github.event.comment.body, '@claude')) || (github.event_name ==
+      'pull_request_review_comment' && contains(github.event.comment.body,
+      '@claude')) || (github.event_name == 'pull_request_review' &&
+      contains(github.event.review.body, '@claude')) || (github.event_name ==
+      'issues' && (contains(github.event.issue.body, '@claude') ||
+      contains(github.event.issue.title, '@claude'))) }}
     runs-on: ubuntu-latest
     # checkov:skip=CKV2_GHA_1
     # id-token write permission is required for OIDC authentication with Claude
@@ -39,7 +37,7 @@ jobs:
 
       - name: Run Claude Code
         id: claude
-        uses: anthropics/claude-code-action@cefe963a6b4ae0e511c59b9d6cb6b7b5923714a1  # yamllint disable-line rule:line-length
+        uses: anthropics/claude-code-action@cefe963a6b4ae0e511c59b9d6cb6b7b5923714a1 # yamllint disable-line rule:line-length
         with:
           claude_code_oauth_token: ${{ secrets.CLAUDE_CODE_OAUTH_TOKEN }}
           # Optional setting that allows Claude to read CI results on PRs
@@ -53,8 +51,7 @@ jobs:
           # assignee_trigger: "claude-bot"
 
           allowed_tools: |
-            "Bash(npm install),Bash(npm run build),"
-            "Bash(npm run test:*),Bash(npm run lint:*)"
+            "Bash(npm install),Bash(npm run build),Bash(npm run test:*),Bash(npm run lint:*)"
 
           # Optional: Add custom instructions for Claude to customize
           # its behavior for your project


### PR DESCRIPTION
## Summary
- Add condition to skip Claude Code Review for Dependabot PRs
- This prevents authentication errors that occur when Dependabot PRs trigger the workflow

## Problem
Dependabot PRs were failing with OIDC authentication errors:
```
App token exchange failed: 401 Unauthorized - User does not have write access on this repository
```

## Solution
Added `if: github.actor \!= 'dependabot[bot]'` condition to the claude-review job to skip execution for Dependabot PRs.

## Changes
- Modified `.github/workflows/claude-code-review.yml` to exclude Dependabot PRs

## Impact
- Normal PRs: Claude Code Review continues to work as expected
- Dependabot PRs: Claude Code Review is skipped, avoiding authentication errors
- Manual review can still be triggered with @claude comment if needed