### PR TITLE
feat: change default value of include_job_summary_anchor to true

### DIFF
--- a/README.md
+++ b/README.md
@@ -45,7 +45,7 @@ default workflow context.
 | `run_attempt`                | The attempt number of the workflow run                                   | No       | `${{ github.run_attempt }}` |
 | `job`                        | The job name                                                             | No       | `${{ github.job }}`         |
 | `github_token`               | GitHub token for API access                                              | No       | `${{ github.token }}`       |
-| `include_job_summary_anchor` | Include anchor to specific job in job_summary_url (e.g., #summary-12345) | No       | `false`                     |
+| `include_job_summary_anchor` | Include anchor to specific job in job_summary_url (e.g., #summary-12345) | No       | `true`                      |
 
 ## Outputs
 

--- a/action.yml
+++ b/action.yml
@@ -38,7 +38,7 @@ inputs:
     description:
       'Include anchor to specific job in job_summary_url (e.g., #summary-12345)'
     required: false
-    default: 'false'
+    default: 'true'
 
 outputs:
   run_url:


### PR DESCRIPTION
## Summary
- Changed the default value of `include_job_summary_anchor` input from `false` to `true`
- This provides users with direct links to specific job summaries by default

## Motivation
Users typically want direct links to specific job summaries within workflow runs. Making this the default behavior improves the user experience by providing more useful URLs without requiring explicit configuration.

## Changes
- Updated `action.yml`: Changed default value of `include_job_summary_anchor` from `'false'` to `'true'`
- Updated `README.md`: Updated documentation to reflect the new default value

🤖 Generated with [Claude Code](https://claude.ai/code)