### PR TITLE
Update bot exclusion in claude-code-review workflow

### DIFF
--- a/.github/workflows/claude-code-review.yml
+++ b/.github/workflows/claude-code-review.yml
@@ -12,8 +12,8 @@ on:
 
 jobs:
   claude-review:
-    # Skip Dependabot PRs
-    if: ${{ github.actor != 'dependabot[bot]' }}
+    # Skip bot PRs
+    if: ${{ !endsWith(github.actor, '[bot]') }}
     # Optional: Filter by PR author
     # if: |
     #   github.event.pull_request.user.login == 'external-contributor' ||


### PR DESCRIPTION
## Summary
This PR updates the bot exclusion logic in the Claude Code Review workflow to be more generic.

## Changes

### Bot Exclusion Update (.github/workflows/claude-code-review.yml)
- Changed bot exclusion from `github.actor != 'dependabot[bot]'` to `!endsWith(github.actor, '[bot]')`
- This now excludes all bot accounts (dependabot[bot], veyronsakai-app[bot], renovate[bot], etc.)
- Makes the exclusion logic more generic and maintainable

## Motivation
Following the same approach successfully implemented in:
- https://github.com/VeyronSakai/qr-code-generator/pull/19

This ensures that Claude Code Review doesn't run on PRs created by any bot accounts, not just Dependabot.

## Testing
- All bot accounts will be properly excluded from Claude Code Review
- Human-created PRs will continue to trigger the review as expected